### PR TITLE
Update node.sh to restart fail2ban after iptables-persist 

### DIFF
--- a/debian/resources/postgresql/node.sh
+++ b/debian/resources/postgresql/node.sh
@@ -81,6 +81,7 @@ if [ .$iptables_add = ."y" ]; then
 	echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections
 	echo iptables-persistent iptables-persistent/autosave_v6 boolean true | debconf-set-selections
 	apt-get install -y iptables-persistent
+	systemctl restart fail2ban
 fi
 
 #setup ssl


### PR DESCRIPTION
When running node.sh and selecting Y to update firewall rules, fail2ban is stopped after iptables-persist runs.
I added systemctl restart fail2ban so that fail2ban is running